### PR TITLE
Bump Node to v14

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update && apt-get install -y sqlite3 libsqlite3-dev curl gnupg \
     && rm -rf /var/lib/apt/lists/*
 ENV FULLSTACK_FOLDER /fullstack-challenges
 WORKDIR $FULLSTACK_FOLDER
-RUN curl -sL https://deb.nodesource.com/setup_11.x  | bash -
+RUN curl -sL https://deb.nodesource.com/setup_14.x  | bash -
 RUN apt-get -y install nodejs
 
 COPY Gemfile $FULLSTACK_FOLDER/Gemfile


### PR DESCRIPTION
Let's bump Glovebox to Node 14, to match students' [current setup](https://github.com/lewagon/setup/blob/master/_partials/nvm.md#node-with-nvm) 👌 

Fixes lewagon/fullstack-challenges#1547