### PR TITLE
update ruby to 2.7.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.6.6
+FROM ruby:2.7.3
 LABEL maintainer="andrey@lewagon.org"
 
 # make the "en_US.UTF-8" locale so ruby will be utf-8 enabled by default

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ git_source(:github) do |repo_name|
   "https://github.com/#{repo_name}.git"
 end
 
-ruby '2.6.6'
+ruby '2.7.3'
 
 # QUESTION: Do we need to lock them to specific versions?
 gem 'awesome_print', '~> 1.8', require: false


### PR DESCRIPTION
This PR update ruby to 2.7.3 to match the ruby version change implemented in [this branch](https://github.com/lewagon/setup/tree/vscode) setup. 

This PR needs to be merged with https://www.notion.so/lewagon/c04b436abeaf4e4dbbe178c81ee47c17?v=cb33c594943b420da5591ed6a55b90f0