### PR TITLE
Bump ruby version to 2.7.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.7.3
+FROM ruby:2.7.4
 LABEL maintainer="andrey@lewagon.org"
 
 # make the "en_US.UTF-8" locale so ruby will be utf-8 enabled by default

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ git_source(:github) do |repo_name|
   "https://github.com/#{repo_name}.git"
 end
 
-ruby '2.7.3'
+ruby '2.7.4'
 
 gem 'awesome_print', '~> 1.8', require: false
 gem 'faker', '~> 2.1'


### PR DESCRIPTION
This updates the **Ruby** version of our Docker image to `2.7.4` accordingly to what we have in the [setup](https://github.com/lewagon/setup/blob/master/macos.md#ruby)

To run on Kitt console after merge

```rb
Program.where(glovebox_endpoint_uri: "https://glovebox2.lewagon.co/api/v1/rake?tag=ruby-2.7.3")
       .update_all(glovebox_endpoint_uri: "https://glovebox2.lewagon.co/api/v1/rake?tag=ruby-2.7.4")
```

@Eschults we might need to run this later after most of our cities livecode (18h CEST) to avoid some issues while building the new image