### PR TITLE
Update ruby version in docker file

### DIFF
--- a/.github/workflows/ghcr_build_latest_on_push.yml
+++ b/.github/workflows/ghcr_build_latest_on_push.yml
@@ -1,6 +1,6 @@
 on:
   push:
-    branches: [master, ruby-3.1.2]
+    branches: [master]
 
 jobs:
   docker:


### PR DESCRIPTION
Actions [failed](https://github.com/lewagon/rake-runner/actions) because I forgot to update the Ruby version in the Docker file :facepalm: This PR fixes it.

I've deleted the release and the associated tag and recreated them. The action is succeeding: https://github.com/lewagon/rake-runner/actions/runs/2507754153