### PR TITLE
Remove js testing gems

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,6 @@ RUN apt-get -y install nodejs
 
 # Binary dependencies for JS testing
 RUN apt-get -y install lsof
-RUN apt-get -y install chromium-chromedriver
 
 COPY Gemfile $FULLSTACK_FOLDER/Gemfile
 RUN ["bundle", "install"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,5 @@ WORKDIR $FULLSTACK_FOLDER
 RUN curl -sL https://deb.nodesource.com/setup_14.x  | bash -
 RUN apt-get -y install nodejs
 
-# Binary dependencies for JS testing
-RUN apt-get -y install lsof
-
 COPY Gemfile $FULLSTACK_FOLDER/Gemfile
 RUN ["bundle", "install"]

--- a/Gemfile
+++ b/Gemfile
@@ -18,5 +18,3 @@ gem "sinatra", "~> 2.2", require: false
 gem "sinatra-contrib", "~> 2.2", require: false
 gem "sqlite3", "~> 1.4"
 gem "activerecord", "~> 7.0"
-gem "watir", "~> 7.2"
-gem "webrick", "~> 1.3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -128,11 +128,6 @@ GEM
       parser (>= 3.2.1.0)
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
-    rubyzip (2.3.2)
-    selenium-webdriver (4.8.1)
-      rexml (~> 3.2, >= 3.2.5)
-      rubyzip (>= 1.2.2, < 3.0)
-      websocket (~> 1.0)
     sinatra (2.2.1)
       mustermann (~> 1.0)
       rack (~> 2.2)
@@ -153,11 +148,6 @@ GEM
       unf_ext
     unf_ext (0.0.8.2)
     unicode-display_width (2.4.2)
-    watir (7.2.2)
-      regexp_parser (>= 1.2, < 3)
-      selenium-webdriver (~> 4.2)
-    webrick (1.8.1)
-    websocket (1.2.9)
     zeitwerk (2.6.0)
 
 PLATFORMS
@@ -178,8 +168,6 @@ DEPENDENCIES
   sinatra (~> 2.2)
   sinatra-contrib (~> 2.2)
   sqlite3 (~> 1.4)
-  watir (~> 7.2)
-  webrick (~> 1.3)
 
 RUBY VERSION
    ruby 3.1.2p20


### PR DESCRIPTION
Chromium-webdriver was causing test to fail, removing them from master branch as they don't seem to be used